### PR TITLE
Introduced generic "double det(double *matr, int dim)" (generic determinant function)

### DIFF
--- a/main.c
+++ b/main.c
@@ -15,7 +15,7 @@ int main(void)
 		p[6] = 1;
 		p[7] = 2;
 		p[8] = 1;
-		double ris = det3x3(p);
+		double ris = det(p,3);
 		free(p);
 	}
 
@@ -27,7 +27,7 @@ int main(void)
 		p2[1] = 2;
 		p2[2] = 3;
 		p2[3] = 1;
-		double ris2 = laplace(p2, 2);
+		double ris2 = det(p2, 2);
 		free(p2);
 	}
 
@@ -36,7 +36,7 @@ int main(void)
 	if (p3)
 	{
 		p3[0] = 4;
-		double ris3 = laplace(p3, 1);
+		double ris3 = det(p3, 1);
 		free(p3);
 	}
 
@@ -53,7 +53,7 @@ int main(void)
 		p4[6] = 1;
 		p4[7] = 2;
 		p4[8] = 1;
-		double ris4 = laplace(p4, 3);
+		double ris4 = det(p4, 3);
 		free(p4);
 	}
 
@@ -77,7 +77,7 @@ int main(void)
 		p5[13] = 1;
 		p5[14] = 1;
 		p5[15] = 1;
-		double ris5 = laplace(p5, 4);
+		double ris5 = det(p5, 4);
 		free(p5);
 	}
 
@@ -110,7 +110,7 @@ int main(void)
 		p6[22] = 0;
 		p6[23] = 1;
 		p6[24] = 0;
-		double ris6 = laplace(p6, 5);
+		double ris6 = det(p6, 5);
 		free(p6);
 	}
 	return 0;

--- a/matrixcomp.c
+++ b/matrixcomp.c
@@ -1,25 +1,68 @@
 // Gianluca Mancusi, Daniele Manicardi, Gianmarco Lusvardi - Unimore
 #include "matrixcomp.h"
 
-double laplace(double *matr, int dim)
+double det(double *matr, int dim)
+{
+	if (matr == NULL || dim <= 0) return 0;
+	if (dim > 3)
+	{
+		double **compm_matrs = NULL; //allocates once all the space for the complementary minors up to 3x3 (...dim-3)
+		compm_matrs = malloc((dim - 3) * sizeof(double*));
+		for (int i = 0; i < dim - 3; i++)
+		{
+			compm_matrs[i] = malloc((i + 3)*(i + 3) * sizeof(double)); //allocate complementary matrix to use: [0] = 3x3... [1] = 4x4... ... [n-1] = (n-1 +3)x(n-1 +3)
+		}
+		double det = laplace(matr, dim, compm_matrs, dim);
+		if (compm_matrs != NULL)
+		{
+			for (int i = 0; i < dim - 3; i++)
+			{
+				free(compm_matrs[i]);
+			}
+			free(compm_matrs);
+		}
+		return det;
+	}
+	return laplace(matr, dim, NULL, 0);
+}
+
+double laplace(double *matr, int dim, double **compm_matrs, int start_dim)
 {
 	double det = 0;
-	if (matr == NULL || dim == 0) return 0;
+	if (matr == NULL || dim <= 0) return 0;
 	else if (dim == 1) return matr[0];
 	else if (dim == 2) return matr[0] * matr[3] - matr[1] * matr[2];
 	else if (dim == 3) return det3x3(matr);
 	for (int i = 0; i < dim; i++)
 	{
-		double* cMinor = compMinor(matr, dim, dim, 0, i);
-		det += (i % 2 == 0 ? 1 : -1) * matr[i] * laplace(cMinor, dim - 1);
-		free(cMinor);
+		if (matr[i] != 0)
+		{
+			double* current_matr = dim == start_dim ? matr : compm_matrs[dim - 3];
+			fillCompMinor(current_matr, compm_matrs[dim-1 - 3], dim, 0, i);
+			det += (i % 2 == 0 ? 1 : -1) * matr[i] * laplace(compm_matrs[dim-1 - 3], dim - 1, compm_matrs, start_dim);
+		}
 	}
 	return det;
 }
 
+void fillCompMinor(const double *src_matr, double *dst_matr, int src_dim, int row, int col)
+{
+	if (src_matr == NULL || dst_matr == NULL || src_dim <= 0 || row < 0 || col < 0 || row >= src_dim || col >= src_dim) return;
+	for (int i = 0, j = 0; i < src_dim*src_dim; i++)
+	{
+		int r = i / src_dim;
+		int c = i % src_dim;
+		if (r != row && c != col)
+		{
+			dst_matr[j] = src_matr[i];
+			j++;
+		}
+	}
+}
+
 double* compMinor(double *matr, int matr_rows, int matr_cols, int row, int col)
 {
-	if (matr == NULL || matr_rows == 0 || matr_cols == 0 || row >= matr_rows || col >= matr_cols) return 0;
+	if (matr == NULL || matr_rows == 0 || matr_cols == 0 || row >= matr_rows || col >= matr_cols) return NULL;
 	double *n_matr = malloc((matr_cols - 1)*(matr_rows - 1) * sizeof(double));
 	if (n_matr)
 	{

--- a/matrixcomp.h
+++ b/matrixcomp.h
@@ -2,7 +2,9 @@
 #ifndef MATRIX_H
 #define MATRIX_H
 #include <stdlib.h>
+extern double det(double *matr, int dim);
+extern void fillCompMinor(const double *src_matr, double *dst_matr, int src_dim, int row, int col);
 extern double* compMinor(double *matr, int matr_rows, int matr_cols, int row, int col);
 extern double det3x3(double *matr);
-extern double laplace(double *matr, int dim);
+extern double laplace(double *matr, int dim, double **compm_matrs, int start_dim);
 #endif //!MATRICE_H


### PR DESCRIPTION
Introduced generic 
`double det(double *matr, int dim);`
whitch calculates the determinant of any matrix.

Improved calculation speed for the Laplace function by "n" times.
suppose "dim" to be the size of the matrix:
Before: (**(dim^2)-3dim**) times called malloc() and free().
Now: **dim-3** times called malloc() and free().

This means that for a 5x5 matrix:
malloc and free are called **2** times

Before in a 5x5 matrix:
malloc and free were called **10** times!

_-G.Mancusi_